### PR TITLE
Bump docker .NET runtime from 5.0.4 to 5.0.5

### DIFF
--- a/PoiDiscordDotNet/Dockerfile
+++ b/PoiDiscordDotNet/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime:5.0.4
+FROM mcr.microsoft.com/dotnet/runtime:5.0.5
 
 RUN sed -i'.bak' 's/$/ contrib/' /etc/apt/sources.list
 RUN apt-get update; apt-get install -y ttf-mscorefonts-installer fontconfig


### PR DESCRIPTION
Because this isn't covered by dependabot just yet apparently...