### PR TITLE
Feature/workaround score saber internal server error responses

### DIFF
--- a/PoiDiscordDotNet/Services/ScoreSaberService.cs
+++ b/PoiDiscordDotNet/Services/ScoreSaberService.cs
@@ -70,7 +70,7 @@ namespace PoiDiscordDotNet.Services
 					},
 					(_, timespan, _, _) =>
 					{
-						_logger.LogInformation($"Hit ScoreSaber rate limit. Retrying in {timespan:g}");
+						_logger.LogInformation("Hit ScoreSaber rate limit. Retrying in {TimeTillReset}", timespan.ToString("g"));
 
 						return Task.CompletedTask;
 					});


### PR DESCRIPTION
This PR adds a workaround for ScoreSaber's api being somewhat unstable at times and returning an HTTP 500 status code every now and then. The added code will result in automated retrying whenever that happens.