### PR TITLE
Added Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+﻿version: 2
+registries:
+    nuget-feed-nuget-emzi0767-com-api-v3-index-json:
+        type: nuget-feed
+        url: https://nuget.emzi0767.com/api/v3/index.json
+updates:
+    - package-ecosystem: nuget
+      directory: "/"
+      schedule:
+          interval: daily
+      open-pull-requests-limit: 10
+      reviewers:
+          - ErisApps
+      assignees:
+          - ErisApps
+      registries:
+          - nuget-feed-nuget-emzi0767-com-api-v3-index-json


### PR DESCRIPTION
The online configuration will be deprecated in favor of this config file in due time... hence why I am adding it now.