### PR TITLE
Fix Dockerfile to use included nuget.config file

### DIFF
--- a/POI.DiscordDotNet.Dockerfile
+++ b/POI.DiscordDotNet.Dockerfile
@@ -7,17 +7,18 @@ RUN apt-get update; apt-get install -y ttf-mscorefonts-installer fontconfig
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
 WORKDIR /src
 
+COPY ["nuget.config", ""]
 COPY ["POI.Core/POI.Core.csproj", "POI.Core/"]
-RUN dotnet restore "POI.Core/POI.Core.csproj"
+RUN dotnet restore "POI.Core/POI.Core.csproj" --configfile "nuget.config"
 COPY ["POI.DiscordDotNet/POI.DiscordDotNet.csproj", "POI.DiscordDotNet/"]
-RUN dotnet restore "POI.DiscordDotNet/POI.DiscordDotNet.csproj"
+RUN dotnet restore "POI.DiscordDotNet/POI.DiscordDotNet.csproj" --configfile "nuget.config"
 
 COPY ["POI.Core/.", "POI.Core/"]
 COPY ["POI.DiscordDotNet/.", "POI.DiscordDotNet/"]
 
 WORKDIR ./POI.DiscordDotNet
-RUN dotnet build "POI.DiscordDotNet.csproj" -c Release -o /app/build
-RUN dotnet publish "POI.DiscordDotNet.csproj" -c Release -o /app/publish
+RUN dotnet build "POI.DiscordDotNet.csproj" --configfile "../nuget.config" -c Release -o /app/build
+RUN dotnet publish "POI.DiscordDotNet.csproj" --configfile "../nuget.config" -c Release -o /app/publish
 
 FROM runtime-env as final
 WORKDIR /app


### PR DESCRIPTION
Due to the usage of nightly DSharpPlus builds (that aren't available on Nuget), the dockerfile build failed due to unresolved dependencies. This PR fixes that issue.