### PR TITLE
Fixed TotalScore and TotalRankedScore being deserialized out-of-bounds

### DIFF
--- a/POI.Core/Models/ScoreSaber/Profile/ScoreStats.cs
+++ b/POI.Core/Models/ScoreSaber/Profile/ScoreStats.cs
@@ -5,10 +5,10 @@ namespace POI.Core.Models.ScoreSaber.Profile
 	public class ScoreStats
 	{
 		[JsonPropertyName("totalScore")]
-		public int TotalScore { get; init; }
+		public ulong TotalScore { get; init; }
 
 		[JsonPropertyName("totalRankedScore")]
-		public int TotalRankedScore { get; init; }
+		public ulong TotalRankedScore { get; init; }
 
 		[JsonPropertyName("averageRankedAccuracy")]
 		public double AverageRankedAccuracy { get; init; }


### PR DESCRIPTION
Pretty much what the title implies. When fetching the full profile from ScoreSaber for people like for example [Garsh](https://new.scoresaber.com/u/76561198187936410), their TotalScore would exceed the max value of an Int32 resulting in a deserialization exception at runtime.