### PR TITLE
Apply ScoreSaber DataContract changes

### DIFF
--- a/POI.Azure/Functions/RankUpFeed/RankUpFeedFunction.cs
+++ b/POI.Azure/Functions/RankUpFeed/RankUpFeedFunction.cs
@@ -53,12 +53,12 @@ namespace POI.Azure.Functions.RankUpFeed
 				logger.LogInformation("Fetching page {PageNumber} for players", internalPage);
 
 				var playersPage = await scoreSaberApiService.FetchPlayers(internalPage, countries: new[] { "BE" }).ConfigureAwait(false);
-				if (players == null)
+				if (playersPage == null)
 				{
 					throw new Exception();
 				}
 
-				players.AddRange(playersPage!);
+				players.AddRange(playersPage.Players);
 			}
 
 			// TODO: Fetch linked non-BE peeps

--- a/POI.Core/Helpers/JSON/ScoreSaberSerializerContext.cs
+++ b/POI.Core/Helpers/JSON/ScoreSaberSerializerContext.cs
@@ -1,14 +1,16 @@
-﻿using System.Collections.Generic;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using POI.Core.Models.ScoreSaber.Profile;
-using POI.Core.Models.ScoreSaber.Scores;
+using POI.Core.Models.ScoreSaber.Wrappers;
 
 namespace POI.Core.Helpers.JSON
 {
 	[JsonSerializable(typeof(Refresh))]
-	[JsonSerializable(typeof(List<BasicProfile>))]
+	[JsonSerializable(typeof(BasicProfile))]
 	[JsonSerializable(typeof(FullProfile))]
-	[JsonSerializable(typeof(List<PlayerScore>))]
+	[JsonSerializable(typeof(LeaderboardsWrapper))]
+	[JsonSerializable(typeof(PlayerScoresWrapper))]
+	[JsonSerializable(typeof(PlayersWrapper))]
+	[JsonSerializable(typeof(ScoresWrapper))]
 	internal partial class ScoreSaberSerializerContext : JsonSerializerContext
 	{
 	}

--- a/POI.Core/Models/ScoreSaber/MetaData.cs
+++ b/POI.Core/Models/ScoreSaber/MetaData.cs
@@ -13,7 +13,7 @@ namespace POI.Core.Models.ScoreSaber
 		[JsonPropertyName("itemsPerPage")]
 		public uint ItemsPerPage { get; }
 
-		[Newtonsoft.Json.JsonConstructor]
+		[JsonConstructor]
 		public MetaData(uint total, uint page, uint itemsPerPage)
 		{
 			Total = total;

--- a/POI.Core/Models/ScoreSaber/MetaData.cs
+++ b/POI.Core/Models/ScoreSaber/MetaData.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.Json.Serialization;
+
+namespace POI.Core.Models.ScoreSaber
+{
+	public readonly struct MetaData
+	{
+		[JsonPropertyName("total")]
+		public uint Total { get; }
+
+		[JsonPropertyName("page")]
+		public uint Page { get; }
+
+		[JsonPropertyName("itemsPerPage")]
+		public uint ItemsPerPage { get; }
+
+		[Newtonsoft.Json.JsonConstructor]
+		public MetaData(uint total, uint page, uint itemsPerPage)
+		{
+			Total = total;
+			Page = page;
+			ItemsPerPage = itemsPerPage;
+		}
+	}
+}

--- a/POI.Core/Models/ScoreSaber/Profile/ExtendedBasicProfile.cs
+++ b/POI.Core/Models/ScoreSaber/Profile/ExtendedBasicProfile.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json.Serialization;
+
+namespace POI.Core.Models.ScoreSaber.Profile
+{
+	public class ExtendedBasicProfile : BasicProfile
+	{
+		[JsonPropertyName("scoreStats")]
+		public ScoreStats ScoreStats { get; }
+
+		public ExtendedBasicProfile(string id, string name, string profilePicture, string country, uint rank, uint countryRank, double pp, string historyRaw, string role, uint permissions,
+			bool inactive, bool banned, ScoreStats scoreStats)
+			: base(id, name, profilePicture, country, rank, countryRank, pp, historyRaw, role, permissions, inactive, banned)
+		{
+			ScoreStats = scoreStats;
+		}
+	}
+}

--- a/POI.Core/Models/ScoreSaber/Profile/FullProfile.cs
+++ b/POI.Core/Models/ScoreSaber/Profile/FullProfile.cs
@@ -3,21 +3,17 @@ using System.Text.Json.Serialization;
 
 namespace POI.Core.Models.ScoreSaber.Profile
 {
-	public class FullProfile : BasicProfile
+	public class FullProfile : ExtendedBasicProfile
 	{
 		[JsonPropertyName("badges")]
 		public List<Badge> Badges { get; }
 
-		[JsonPropertyName("scoreStats")]
-		public ScoreStats ScoreStats { get; }
-
 		[JsonConstructor]
 		public FullProfile(string id, string name, string profilePicture, string country, uint rank, uint countryRank, double pp, string historyRaw, string role, uint permissions, bool inactive,
 			bool banned, List<Badge> badges, ScoreStats scoreStats)
-			: base(id, name, profilePicture, country, rank, countryRank, pp, historyRaw, role, permissions, inactive, banned)
+			: base(id, name, profilePicture, country, rank, countryRank, pp, historyRaw, role, permissions, inactive, banned, scoreStats)
 		{
 			Badges = badges;
-			ScoreStats = scoreStats;
 		}
 	}
 }

--- a/POI.Core/Models/ScoreSaber/Wrappers/BaseWrapper.cs
+++ b/POI.Core/Models/ScoreSaber/Wrappers/BaseWrapper.cs
@@ -1,0 +1,15 @@
+﻿using System.Text.Json.Serialization;
+
+namespace POI.Core.Models.ScoreSaber.Wrappers
+{
+	public abstract class BaseWrapper
+	{
+		[JsonPropertyName("metadata")]
+		public MetaData MetaData { get; }
+
+		protected BaseWrapper(MetaData metaData)
+		{
+			MetaData = metaData;
+		}
+	}
+}

--- a/POI.Core/Models/ScoreSaber/Wrappers/LeaderboardsWrapper.cs
+++ b/POI.Core/Models/ScoreSaber/Wrappers/LeaderboardsWrapper.cs
@@ -9,6 +9,7 @@ namespace POI.Core.Models.ScoreSaber.Wrappers
 		[JsonPropertyName("leaderboards")]
 		public List<LeaderboardInfo> Leaderboards { get; }
 
+		[JsonConstructor]
 		public LeaderboardsWrapper(List<LeaderboardInfo> leaderboards, MetaData metaData) : base(metaData)
 		{
 			Leaderboards = leaderboards;

--- a/POI.Core/Models/ScoreSaber/Wrappers/LeaderboardsWrapper.cs
+++ b/POI.Core/Models/ScoreSaber/Wrappers/LeaderboardsWrapper.cs
@@ -4,6 +4,9 @@ using POI.Core.Models.ScoreSaber.Scores;
 
 namespace POI.Core.Models.ScoreSaber.Wrappers
 {
+	/// <remark>
+	/// This class matches the LeaderboardInfoCollection object in the swagger documentation
+	/// </remark>
 	public class LeaderboardsWrapper : BaseWrapper
 	{
 		[JsonPropertyName("leaderboards")]

--- a/POI.Core/Models/ScoreSaber/Wrappers/LeaderboardsWrapper.cs
+++ b/POI.Core/Models/ScoreSaber/Wrappers/LeaderboardsWrapper.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using POI.Core.Models.ScoreSaber.Scores;
+
+namespace POI.Core.Models.ScoreSaber.Wrappers
+{
+	public class LeaderboardsWrapper : BaseWrapper
+	{
+		[JsonPropertyName("leaderboards")]
+		public List<LeaderboardInfo> Leaderboards { get; }
+
+		public LeaderboardsWrapper(List<LeaderboardInfo> leaderboards, MetaData metaData) : base(metaData)
+		{
+			Leaderboards = leaderboards;
+		}
+	}
+}

--- a/POI.Core/Models/ScoreSaber/Wrappers/PlayerScoresWrapper.cs
+++ b/POI.Core/Models/ScoreSaber/Wrappers/PlayerScoresWrapper.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using POI.Core.Models.ScoreSaber.Scores;
+
+namespace POI.Core.Models.ScoreSaber.Wrappers
+{
+	public class PlayerScoresWrapper : BaseWrapper
+	{
+		[JsonPropertyName("playerScores")]
+		public List<PlayerScore> PlayerScores { get; }
+
+		[JsonConstructor]
+		public PlayerScoresWrapper(List<PlayerScore> playerScores, MetaData metaData) : base(metaData)
+		{
+			PlayerScores = playerScores;
+		}
+	}
+}

--- a/POI.Core/Models/ScoreSaber/Wrappers/PlayerScoresWrapper.cs
+++ b/POI.Core/Models/ScoreSaber/Wrappers/PlayerScoresWrapper.cs
@@ -4,6 +4,9 @@ using POI.Core.Models.ScoreSaber.Scores;
 
 namespace POI.Core.Models.ScoreSaber.Wrappers
 {
+	/// <remark>
+	/// This class matches the PlayerScoreCollection object in the swagger documentation
+	/// </remark>
 	public class PlayerScoresWrapper : BaseWrapper
 	{
 		[JsonPropertyName("playerScores")]

--- a/POI.Core/Models/ScoreSaber/Wrappers/PlayersWrapper.cs
+++ b/POI.Core/Models/ScoreSaber/Wrappers/PlayersWrapper.cs
@@ -12,6 +12,7 @@ namespace POI.Core.Models.ScoreSaber.Wrappers
 		[JsonPropertyName("players")]
 		public List<ExtendedBasicProfile> Players { get; }
 
+		[JsonConstructor]
 		public PlayersWrapper(List<ExtendedBasicProfile> players, MetaData metaData) : base(metaData)
 		{
 			Players = players;

--- a/POI.Core/Models/ScoreSaber/Wrappers/PlayersWrapper.cs
+++ b/POI.Core/Models/ScoreSaber/Wrappers/PlayersWrapper.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using POI.Core.Models.ScoreSaber.Profile;
+
+namespace POI.Core.Models.ScoreSaber.Wrappers
+{
+	/// <remark>
+	/// This class matches the PlayersCollection object in the swagger documentation
+	/// </remark>
+	public class PlayersWrapper : BaseWrapper
+	{
+		[JsonPropertyName("players")]
+		public List<ExtendedBasicProfile> Players { get; }
+
+		public PlayersWrapper(List<ExtendedBasicProfile> players, MetaData metaData) : base(metaData)
+		{
+			Players = players;
+		}
+	}
+}

--- a/POI.Core/Models/ScoreSaber/Wrappers/PlayersWrapper.cs
+++ b/POI.Core/Models/ScoreSaber/Wrappers/PlayersWrapper.cs
@@ -5,7 +5,7 @@ using POI.Core.Models.ScoreSaber.Profile;
 namespace POI.Core.Models.ScoreSaber.Wrappers
 {
 	/// <remark>
-	/// This class matches the PlayersCollection object in the swagger documentation
+	/// This class matches the PlayerCollection object in the swagger documentation
 	/// </remark>
 	public class PlayersWrapper : BaseWrapper
 	{

--- a/POI.Core/Models/ScoreSaber/Wrappers/ScoresWrapper.cs
+++ b/POI.Core/Models/ScoreSaber/Wrappers/ScoresWrapper.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using POI.Core.Models.ScoreSaber.Scores;
+
+namespace POI.Core.Models.ScoreSaber.Wrappers
+{
+	public class ScoresWrapper : BaseWrapper
+	{
+		[JsonPropertyName("scores")]
+		public List<Score> Scores { get; }
+
+		[JsonConstructor]
+		public ScoresWrapper(List<Score> scores, MetaData metaData) : base(metaData)
+		{
+			Scores = scores;
+		}
+	}
+}

--- a/POI.Core/Models/ScoreSaber/Wrappers/ScoresWrapper.cs
+++ b/POI.Core/Models/ScoreSaber/Wrappers/ScoresWrapper.cs
@@ -4,6 +4,9 @@ using POI.Core.Models.ScoreSaber.Scores;
 
 namespace POI.Core.Models.ScoreSaber.Wrappers
 {
+	/// <remark>
+	/// This class matches the ScoreCollection object in the swagger documentation
+	/// </remark>
 	public class ScoresWrapper : BaseWrapper
 	{
 		[JsonPropertyName("scores")]

--- a/POI.Core/Services/ScoreSaberApiService.cs
+++ b/POI.Core/Services/ScoreSaberApiService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -14,7 +13,7 @@ using NodaTime.Serialization.SystemTextJson;
 using POI.Core.Exceptions;
 using POI.Core.Helpers.JSON;
 using POI.Core.Models.ScoreSaber.Profile;
-using POI.Core.Models.ScoreSaber.Scores;
+using POI.Core.Models.ScoreSaber.Wrappers;
 using POI.Core.Services.Interfaces;
 using Polly;
 using Polly.Bulkhead;
@@ -113,17 +112,17 @@ namespace POI.Core.Services
 			return FetchDataClass($"{SCORESABER_API_BASEURL}player/{scoreSaberId}/full", _scoreSaberSerializerContext.FullProfile);
 		}
 
-		public Task<List<PlayerScore>?> FetchRecentSongsScorePage(string scoreSaberId, uint page, uint? limit = null)
+		public Task<PlayerScoresWrapper?> FetchRecentSongsScorePage(string scoreSaberId, uint page, uint? limit = null)
 		{
 			return FetchPlayerScores(scoreSaberId, page, SortType.Recent, limit);
 		}
 
-		public Task<List<PlayerScore>?> FetchTopSongsScorePage(string scoreSaberId, uint page, uint? limit = null)
+		public Task<PlayerScoresWrapper?> FetchTopSongsScorePage(string scoreSaberId, uint page, uint? limit = null)
 		{
 			return FetchPlayerScores(scoreSaberId, page, SortType.Top, limit);
 		}
 
-		public Task<List<PlayerScore>?> FetchPlayerScores(string scoreSaberId, uint page, SortType sortType, uint? limit = null)
+		public Task<PlayerScoresWrapper?> FetchPlayerScores(string scoreSaberId, uint page, SortType sortType, uint? limit = null)
 		{
 			var urlBuilder = new StringBuilder(SCORESABER_API_BASEURL + "player/" + scoreSaberId + "/scores?page=" + page + "&sort=" + sortType.ToString("G").ToLower());
 			if (limit != null)
@@ -136,12 +135,12 @@ namespace POI.Core.Services
 				urlBuilder.Append("&limit=").Append(limit);
 			}
 
-			return FetchDataClass(urlBuilder.ToString(), _scoreSaberSerializerContext.ListPlayerScore);
+			return FetchDataClass(urlBuilder.ToString(), _scoreSaberSerializerContext.PlayerScoresWrapper);
 		}
 
 		// TODO: Add intermediate model inheriting from BasicProfile that contains ScoreStats but doesn't have badges
 		// using FullProfile would be violating the nullability constraint of the Badges property
-		public Task<List<BasicProfile>?> FetchPlayers(uint page, string? searchQuery = null, string[]? countries = null)
+		public Task<PlayersWrapper?> FetchPlayers(uint page, string? searchQuery = null, string[]? countries = null)
 		{
 			var urlBuilder = new StringBuilder(SCORESABER_API_BASEURL + "players?page=" + page);
 			if (searchQuery != null)
@@ -155,7 +154,7 @@ namespace POI.Core.Services
 				urlBuilder.Append("?countries=").Append(string.Join(',', countries));
 			}
 
-			return FetchDataClass(urlBuilder.ToString(), _scoreSaberSerializerContext.ListBasicProfile);
+			return FetchDataClass(urlBuilder.ToString(), _scoreSaberSerializerContext.PlayersWrapper);
 		}
 
 		public Task<Refresh?> RefreshProfile(string scoreSaberId)

--- a/POI.DiscordDotNet/Commands/BeatSaber/BaseSongCommand.cs
+++ b/POI.DiscordDotNet/Commands/BeatSaber/BaseSongCommand.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,6 +11,7 @@ using NodaTime;
 using POI.Core.Models.BeatSavior;
 using POI.Core.Models.ScoreSaber.Profile;
 using POI.Core.Models.ScoreSaber.Scores;
+using POI.Core.Models.ScoreSaber.Wrappers;
 using POI.Core.Services;
 using POI.DiscordDotNet.Commands.Modules;
 using POI.DiscordDotNet.Extensions;
@@ -48,7 +48,7 @@ namespace POI.DiscordDotNet.Commands.BeatSaber
 			_erisSignaturePath = erisSignaturePath;
 		}
 
-		protected abstract Task<List<PlayerScore>?> FetchScorePage(string playerId, uint page);
+		protected abstract Task<PlayerScoresWrapper?> FetchScorePage(string playerId, uint page);
 
 		// ReSharper disable once CognitiveComplexity
 		protected async Task GenerateScoreImageAndSendInternal(CommandContext ctx)
@@ -81,9 +81,9 @@ namespace POI.DiscordDotNet.Commands.BeatSaber
 
 			PlayerScore requestedSong;
 			var localSongIndex = --nthSong % ScoreSaberApiService.PLAYS_PER_PAGE;
-			if (songPage.Count > localSongIndex)
+			if (songPage.PlayerScores.Count > localSongIndex)
 			{
-				requestedSong = songPage[localSongIndex];
+				requestedSong = songPage.PlayerScores[localSongIndex];
 			}
 			else
 			{

--- a/POI.DiscordDotNet/Commands/BeatSaber/CompareCommand.cs
+++ b/POI.DiscordDotNet/Commands/BeatSaber/CompareCommand.cs
@@ -109,7 +109,7 @@ namespace POI.DiscordDotNet.Commands.BeatSaber
 				new[] {profile1.ScoreStats.TotalRankedCount.ToString("N0"), "Ranked Play Count", profile2.ScoreStats.TotalRankedCount.ToString("N0")},
 				new[] {profile1.ScoreStats.TotalScore.ToString("N0"), "Score", profile2.ScoreStats.TotalScore.ToString("N0")},
 				new[] {profile1.ScoreStats.TotalRankedScore.ToString("N0"), "Ranked Score", profile2.ScoreStats.TotalRankedScore.ToString("N0")},
-				new[] {profile1TopPage[0].Score.Pp.ToString("N2"), "Top PP Play", profile2TopPage[0].Score.Pp.ToString("N2")}
+				new[] {profile1TopPage.PlayerScores[0].Score.Pp.ToString("N2"), "Top PP Play", profile2TopPage.PlayerScores[0].Score.Pp.ToString("N2")}
 			};
 
 			await using var memoryStream = new MemoryStream();

--- a/POI.DiscordDotNet/Commands/BeatSaber/RecentSongCommand.cs
+++ b/POI.DiscordDotNet/Commands/BeatSaber/RecentSongCommand.cs
@@ -1,11 +1,10 @@
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using Microsoft.Extensions.Logging;
-using POI.Core.Models.ScoreSaber.Scores;
+using POI.Core.Models.ScoreSaber.Wrappers;
 using POI.Core.Services;
 using POI.DiscordDotNet.Services;
 
@@ -27,7 +26,7 @@ namespace POI.DiscordDotNet.Commands.BeatSaber
 			await GenerateScoreImageAndSendInternal(ctx);
 		}
 
-		protected override Task<List<PlayerScore>?> FetchScorePage(string playerId, uint page)
+		protected override Task<PlayerScoresWrapper?> FetchScorePage(string playerId, uint page)
 		{
 			return ScoreSaberApiService.FetchRecentSongsScorePage(playerId, page);
 		}

--- a/POI.DiscordDotNet/Commands/BeatSaber/TopSongCommand.cs
+++ b/POI.DiscordDotNet/Commands/BeatSaber/TopSongCommand.cs
@@ -1,11 +1,10 @@
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using Microsoft.Extensions.Logging;
-using POI.Core.Models.ScoreSaber.Scores;
+using POI.Core.Models.ScoreSaber.Wrappers;
 using POI.Core.Services;
 using POI.DiscordDotNet.Services;
 
@@ -27,7 +26,7 @@ namespace POI.DiscordDotNet.Commands.BeatSaber
 			await GenerateScoreImageAndSendInternal(ctx).ConfigureAwait(false);
 		}
 
-		protected override Task<List<PlayerScore>?> FetchScorePage(string playerId, uint page)
+		protected override Task<PlayerScoresWrapper?> FetchScorePage(string playerId, uint page)
 		{
 			return ScoreSaberApiService.FetchTopSongsScorePage(playerId, page);
 		}


### PR DESCRIPTION
This PR basically changes the ScoreSaber API DataContract models to align with the changes of December 10 2021

It's probably missing some xml docs here and there, but that shouldn't affect the actual working of things.