### PR TITLE
Increase ScoreSaber API max parallelization from 1 to 4

### DIFF
--- a/POI.Core/Services/ScoreSaberApiService.cs
+++ b/POI.Core/Services/ScoreSaberApiService.cs
@@ -83,7 +83,7 @@ namespace POI.Core.Services
 					});
 
 			_scoreSaberApiBulkheadPolicy = Policy.BulkheadAsync<HttpResponseMessage>(
-				1,
+				4,
 				MAX_BULKHEAD_QUEUE_SIZE, // Allow calls to queue indef
 				_ =>
 				{


### PR DESCRIPTION
Currently, only 1 concurrent API call is allowed, however, this introduces some unnecessary wait times when commands try to invoke multiple calls simultaneously or multiple processes end up invoking an API call. Currently increased the max concurrency from 1 to 4, but this might be subject to change in the future.