### PR TITLE
Feature/Initial RankUpFeed implementation

### DIFF
--- a/POI.DiscordDotNet/Bootstrapper.cs
+++ b/POI.DiscordDotNet/Bootstrapper.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Specialized;
 using System.Globalization;
 using System.Reflection;
 using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.Entities;
-using DSharpPlus.Interactivity;
 using DSharpPlus.Interactivity.Extensions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;

--- a/POI.DiscordDotNet/Bootstrapper.cs
+++ b/POI.DiscordDotNet/Bootstrapper.cs
@@ -111,8 +111,7 @@ namespace POI.DiscordDotNet
 
 						q.ScheduleJob<RankUpFeedJob>(trigger => trigger
 							.WithIdentity("RankUpFeed Trigger")
-							.StartNow());
-						//.WithSchedule(CronScheduleBuilder.CronSchedule("0 0/5 * * * ?")));
+							.WithSchedule(CronScheduleBuilder.CronSchedule("0 0/5 * * * ?")));
 					});
 				}).Build();
 

--- a/POI.DiscordDotNet/Bootstrapper.cs
+++ b/POI.DiscordDotNet/Bootstrapper.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using POI.Core.Extensions;
 using POI.Core.Services.Interfaces;
+using POI.DiscordDotNet.Jobs;
 using POI.DiscordDotNet.Services;
 using POI.DiscordDotNet.Services.Interfaces;
 using Quartz;
@@ -90,6 +91,8 @@ namespace POI.DiscordDotNet
 					sc.AddSingleton<UptimeManagementService>();
 					sc.AddSingleton<ScoreSaberLinkService>();
 
+					sc.AddSingleton<RankUpFeedJob>();
+
 					sc.AddQuartz(q =>
 					{
 						// handy when part of cluster or you want to otherwise identify multiple schedulers
@@ -105,6 +108,11 @@ namespace POI.DiscordDotNet
 						{
 							tp.MaxConcurrency = 5;
 						});
+
+						q.ScheduleJob<RankUpFeedJob>(trigger => trigger
+							.WithIdentity("RankUpFeed Trigger")
+							.StartNow());
+						//.WithSchedule(CronScheduleBuilder.CronSchedule("0 0/5 * * * ?")));
 					});
 				}).Build();
 

--- a/POI.DiscordDotNet/Jobs/RankUpFeedJob.cs
+++ b/POI.DiscordDotNet/Jobs/RankUpFeedJob.cs
@@ -33,6 +33,7 @@ namespace POI.DiscordDotNet.Jobs
 			var acquiredLock = await _concurrentExecutionSemaphoreSlim.WaitAsync(0).ConfigureAwait(false);
 			if (!acquiredLock)
 			{
+				_logger.LogWarning("Couldn't acquire lock. Job is still running...");
 				return;
 			}
 

--- a/POI.DiscordDotNet/Jobs/RankUpFeedJob.cs
+++ b/POI.DiscordDotNet/Jobs/RankUpFeedJob.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -112,12 +111,14 @@ namespace POI.DiscordDotNet.Jobs
 				if (currentTopRoles.All(role => role.Id != applicableRole.Id))
 				{
 					_logger.LogInformation("Granting {PlayerName} role {RoleName}", member.DisplayName, applicableRole.Name);
+					await member.GrantRoleAsync(applicableRole, "RankUpFeed update").ConfigureAwait(false);
 				}
 
 				// TODO: Revoke all other top roles if needed
 				foreach (var revocableRole in currentTopRoles.Where(role => role.Id != applicableRole.Id))
 				{
 					_logger.LogInformation("Revoking role {RoleName} for {PlayerName}", revocableRole.Name, member.DisplayName);
+					await member.RevokeRoleAsync(revocableRole, "RankUpFeed update").ConfigureAwait(false);
 				}
 			}
 

--- a/POI.DiscordDotNet/Jobs/RankUpFeedJob.cs
+++ b/POI.DiscordDotNet/Jobs/RankUpFeedJob.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DSharpPlus;
+using Microsoft.Extensions.Logging;
+using POI.Core.Services;
+using POI.DiscordDotNet.Services;
+using Quartz;
+
+namespace POI.DiscordDotNet.Jobs
+{
+	public class RankUpFeedJob : IJob
+	{
+		private readonly ILogger<RankUpFeedJob> _logger;
+		private readonly DiscordClient _discordClient;
+		private readonly ScoreSaberApiService _scoreSaberApiService;
+		private readonly ScoreSaberLinkService _scoreSaberLinkService;
+
+		private readonly SemaphoreSlim _concurrentExecutionSemaphoreSlim = new(1, 1);
+
+		public RankUpFeedJob(ILogger<RankUpFeedJob> logger, DiscordClient discordClient, ScoreSaberApiService scoreSaberApiService, ScoreSaberLinkService scoreSaberLinkService)
+		{
+			_logger = logger;
+			_discordClient = discordClient;
+			_scoreSaberApiService = scoreSaberApiService;
+			_scoreSaberLinkService = scoreSaberLinkService;
+		}
+
+		public async Task Execute(IJobExecutionContext context)
+		{
+			var acquiredLock = await _concurrentExecutionSemaphoreSlim.WaitAsync(0).ConfigureAwait(false);
+			if (!acquiredLock)
+			{
+				return;
+			}
+
+			try
+			{
+				await ExecuteInternal(context).ConfigureAwait(false);
+			}
+			finally
+			{
+				_concurrentExecutionSemaphoreSlim.Release();
+			}
+		}
+
+		private async Task ExecuteInternal(IJobExecutionContext context)
+		{
+			_logger.LogInformation("Heya there from the very first job");
+
+			var allScoreSaberLinks = await _scoreSaberLinkService.GetAll().ConfigureAwait(false);
+			var guild = await _discordClient.GetGuildAsync(561207570669371402, true).ConfigureAwait(false);
+
+			var members = await guild.GetAllMembersAsync();
+			if (members == null)
+			{
+				return;
+			}
+
+			var countryDefinition = new[] { "BE" };
+
+			var playersWrappers = await Task.WhenAll(
+				_scoreSaberApiService.FetchPlayers(1, countries: countryDefinition),
+				_scoreSaberApiService.FetchPlayers(2, countries: countryDefinition),
+				_scoreSaberApiService.FetchPlayers(3, countries: countryDefinition),
+				_scoreSaberApiService.FetchPlayers(4, countries: countryDefinition));
+
+			if (playersWrappers.Any(x => x == null))
+			{
+				return;
+			}
+
+			var roles = guild.Roles.Where(x => x.Value.Name.Contains("(Top ", StringComparison.Ordinal));
+
+			var players = playersWrappers.SelectMany(x => x!.Players).ToList();
+			foreach (var player in players)
+			{
+				_logger.LogDebug("#{Rank} {Name}", player.CountryRank, player.Name);
+
+				var player1 = player;
+				var discordId = allScoreSaberLinks.FirstOrDefault(x => x.ScoreSaberId == player1.Id)?.DiscordId;
+				if (discordId == null)
+				{
+					_logger.LogWarning("Has no link");
+					continue;
+				}
+
+				var member = members.FirstOrDefault(x => string.Equals(x.Id.ToString(), discordId, StringComparison.Ordinal));
+				if (member == null)
+				{
+					_logger.LogWarning("ScoreLink exists for non-member");
+					continue;
+				}
+
+				var currentTopRole = member.Roles.FirstOrDefault(x => x.Name.Contains("(Top ", StringComparison.Ordinal));
+				_logger.LogDebug("Currently has role {RoleName}", currentTopRole?.Name);
+			}
+
+			Debugger.Break();
+		}
+	}
+}

--- a/POI.DiscordDotNet/Jobs/RankUpFeedJob.cs
+++ b/POI.DiscordDotNet/Jobs/RankUpFeedJob.cs
@@ -57,7 +57,7 @@ namespace POI.DiscordDotNet.Jobs
 
 		private async Task ExecuteInternal(IJobExecutionContext context)
 		{
-			_logger.LogInformation("Heya there from the very first job");
+			_logger.LogInformation("Executing RankUpFeed logic");
 
 			var allScoreSaberLinks = await _scoreSaberLinkService.GetAll().ConfigureAwait(false);
 			var guild = await _discordClient.GetGuildAsync(561207570669371402, true).ConfigureAwait(false);
@@ -107,14 +107,14 @@ namespace POI.DiscordDotNet.Jobs
 
 				var applicableRole = DetermineApplicableRole(roles, player.Rank);
 
-				// TODO: Check whether the applicable role is granted
+				// Check whether the applicable role is granted
 				if (currentTopRoles.All(role => role.Id != applicableRole.Id))
 				{
 					_logger.LogInformation("Granting {PlayerName} role {RoleName}", member.DisplayName, applicableRole.Name);
 					await member.GrantRoleAsync(applicableRole, "RankUpFeed update").ConfigureAwait(false);
 				}
 
-				// TODO: Revoke all other top roles if needed
+				// Revoke all other top roles if needed
 				foreach (var revocableRole in currentTopRoles.Where(role => role.Id != applicableRole.Id))
 				{
 					_logger.LogInformation("Revoking role {RoleName} for {PlayerName}", revocableRole.Name, member.DisplayName);

--- a/POI.DiscordDotNet/Models/Database/LeaderboardEntry.cs
+++ b/POI.DiscordDotNet/Models/Database/LeaderboardEntry.cs
@@ -1,0 +1,22 @@
+﻿using MongoDB.Bson.Serialization.Attributes;
+
+namespace POI.DiscordDotNet.Models.Database
+{
+	public class LeaderboardEntry
+	{
+		[BsonId]
+		public string ScoreSaberId { get; }
+
+		public string Name { get; }
+
+		public uint CountryRank { get; }
+
+		[BsonConstructor]
+		public LeaderboardEntry(string scoreSaberId, string name, uint countryRank)
+		{
+			ScoreSaberId = scoreSaberId;
+			Name = name;
+			CountryRank = countryRank;
+		}
+	}
+}

--- a/POI.DiscordDotNet/POI.DiscordDotNet.csproj
+++ b/POI.DiscordDotNet/POI.DiscordDotNet.csproj
@@ -22,6 +22,8 @@
         <PackageReference Include="NodaTime" Version="3.0.9" />
         <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
         <PackageReference Include="Polly" Version="7.2.3" />
+        <PackageReference Include="Quartz" Version="3.3.3" />
+        <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.3.3" />
         <PackageReference Include="Serilog.AspNetCore" Version="4.1.1-dev-00250" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.2-dev-00890" />

--- a/POI.DiscordDotNet/Services/ScoreSaberLinkService.cs
+++ b/POI.DiscordDotNet/Services/ScoreSaberLinkService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -25,6 +26,8 @@ namespace POI.DiscordDotNet.Services
 		internal async Task<string?> LookupScoreSaberId(string discordId) => (await LookupLinkByDiscordId(discordId).ConfigureAwait(false))?.ScoreSaberId;
 
 		internal async Task<string?> LookupDiscordId(string scoreSaberId) => (await LookupLinkByScoreSaberId(scoreSaberId).ConfigureAwait(false))?.DiscordId;
+
+		internal async Task<List<ScoreSaberLink>> GetAll() => await (await GetScoreSaberLinkCollection().FindAsync(_ => true)).ToListAsync();
 
 		internal Task CreateOrUpdateScoreSaberLink(string discordId, string scoreSaberId)
 		{


### PR DESCRIPTION
This PR adds an initial implementation for the RankUpFeed logic.
It will serve as a stopgap solution until we get around to fully re-implementing it at a later time.

This PR also adds the Quartz package, it's a package to help with time-triggered jobs.

Furthermore, the RankUpFeedJob has some code that could be abstracted to its own service later.
More specifically the role management logic

Other than that, it _should_ work... _probably..._