### PR TITLE
Workaround for crash of link command when the country property returns empty

### DIFF
--- a/POI.DiscordDotNet/Commands/BeatSaber/BaseLinkCommand.cs
+++ b/POI.DiscordDotNet/Commands/BeatSaber/BaseLinkCommand.cs
@@ -69,7 +69,7 @@ namespace POI.DiscordDotNet.Commands.BeatSaber
 				.WithTitle(title)
 				.WithDescription("ScoreSaberId Regex matching and validation result")
 				.AddField("Name", basicProfile.Name, true)
-				.AddField("Country", basicProfile.Country, true)
+				.AddField("Country", !string.IsNullOrWhiteSpace(basicProfile.Country) ? basicProfile.Country : "N/A", true)
 				.AddField("Rank", basicProfile.Rank.ToString(), true)
 				.WithFooter($"Request valid for 2 hours (until: {DateTimeOffset.Now.AddHours(2):G}");
 


### PR DESCRIPTION
Basically what the PR title implied.

When a new user plays for the very first time using ScoreSaber, it will set up their account. However, due to internal processes on ScoreSaber's end, it might lagging a bit behind in regard of the country information. (as can be seen in the screenshot below)
![image](https://user-images.githubusercontent.com/25928757/166163735-572ab455-a53f-4c72-b3ec-3fbccfdb518f.png)
