### PR TITLE
Remove custom nuget.config file

### DIFF
--- a/POI.DiscordDotNet.Dockerfile
+++ b/POI.DiscordDotNet.Dockerfile
@@ -9,16 +9,16 @@ WORKDIR /src
 
 COPY ["NuGet.Config", ""]
 COPY ["POI.Core/POI.Core.csproj", "POI.Core/"]
-RUN dotnet restore "POI.Core/POI.Core.csproj" --configfile "NuGet.Config"
+RUN dotnet restore "POI.Core/POI.Core.csproj"
 COPY ["POI.DiscordDotNet/POI.DiscordDotNet.csproj", "POI.DiscordDotNet/"]
-RUN dotnet restore "POI.DiscordDotNet/POI.DiscordDotNet.csproj" --configfile "NuGet.Config"
+RUN dotnet restore "POI.DiscordDotNet/POI.DiscordDotNet.csproj"
 
 COPY ["POI.Core/.", "POI.Core/"]
 COPY ["POI.DiscordDotNet/.", "POI.DiscordDotNet/"]
 
 WORKDIR ./POI.DiscordDotNet
-RUN dotnet build "POI.DiscordDotNet.csproj" --configfile "../NuGet.Config" -c Release -o /app/build
-RUN dotnet publish "POI.DiscordDotNet.csproj" --configfile "../NuGet.Config" -c Release -o /app/publish
+RUN dotnet build "POI.DiscordDotNet.csproj" -c Release -o /app/build
+RUN dotnet publish "POI.DiscordDotNet.csproj" -c Release -o /app/publish
 
 FROM runtime-env as final
 WORKDIR /app

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-	<packageSources>
-		<add key="DSharpPlusSlimGet" value="https://nuget.emzi0767.com/api/v3/index.json" />
-		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-	</packageSources>
-</configuration>


### PR DESCRIPTION
Custom nuget.config file isn't needed anymore as the custom feed itself became obsolete due to pre-release versions of DSharpPlus getting published onto Nuget itself since a few months.