### PR TITLE
Move util commands to slashcommand system

### DIFF
--- a/POI.DiscordDotNet/Bootstrapper.cs
+++ b/POI.DiscordDotNet/Bootstrapper.cs
@@ -193,6 +193,8 @@ namespace POI.DiscordDotNet
 
 			// TODO: Register slash commands below
 			// Eg: slashCommands.RegisterCommands<TestSlashCommand>();
+			slashCommands.RegisterCommands<PingCommand>();
+			slashCommands.RegisterCommands<UptimeCommand>();
 		}
 	}
 }

--- a/POI.DiscordDotNet/Bootstrapper.cs
+++ b/POI.DiscordDotNet/Bootstrapper.cs
@@ -6,7 +6,6 @@ using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.Entities;
 using DSharpPlus.Interactivity.Extensions;
-using DSharpPlus.SlashCommands;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -125,11 +124,14 @@ namespace POI.DiscordDotNet
 
 			_client.UseInteractivity();
 
-			SetupSlashCommands(hostBuilder.Services, logger);
+			var slashCommandsManagementService = hostBuilder.Services.GetRequiredService<SlashCommandsManagementService>()!;
+			slashCommandsManagementService.Setup();
+
+			_ = hostBuilder.Services.GetRequiredService<UptimeManagementService>();
 
 			await _client.ConnectAsync(new DiscordActivity("POI for mod? (pretty please)", ActivityType.Playing)).ConfigureAwait(false);
 
-			var scheduler = await hostBuilder.Services.GetService<ISchedulerFactory>()!.GetScheduler();
+			var scheduler = await hostBuilder.Services.GetRequiredService<ISchedulerFactory>().GetScheduler();
 			await scheduler.Start();
 
 			await hostBuilder.RunAsync().ConfigureAwait(false);
@@ -137,7 +139,7 @@ namespace POI.DiscordDotNet
 
 		private static async Task<bool> VerifyMongoDbConnection(IServiceProvider serviceProvider, Serilog.ILogger logger)
 		{
-			var mongoDbService = serviceProvider.GetService<MongoDbService>()!;
+			var mongoDbService = serviceProvider.GetRequiredService<MongoDbService>();
 			if (await mongoDbService.TestConnectivity().ConfigureAwait(false))
 			{
 				logger.Information("Connected to MongoDb instance");

--- a/POI.DiscordDotNet/Bootstrapper.cs
+++ b/POI.DiscordDotNet/Bootstrapper.cs
@@ -89,6 +89,7 @@ namespace POI.DiscordDotNet
 					sc.AddSingleton<MongoDbService>();
 					sc.AddSingleton<UptimeManagementService>();
 					sc.AddSingleton<ScoreSaberLinkService>();
+					sc.AddSingleton<SlashCommandsManagementService>();
 
 					sc.AddSingleton<RankUpFeedJob>();
 
@@ -148,6 +149,7 @@ namespace POI.DiscordDotNet
 			return false;
 		}
 
+		// TODO: Deprecate in due time...
 		private static void SetupCommandsNext(IServiceProvider services, Serilog.ILogger logger, ConfigProviderService configProvider)
 		{
 			var commandsNext = _client.UseCommandsNext(new CommandsNextConfiguration
@@ -173,28 +175,6 @@ namespace POI.DiscordDotNet
 				return Task.CompletedTask;
 			};
 			commandsNext.RegisterCommands(Assembly.GetEntryAssembly());
-		}
-
-		private static void SetupSlashCommands(IServiceProvider services, Serilog.ILogger logger)
-		{
-			var slashCommands = _client.UseSlashCommands(new SlashCommandsConfiguration { Services = services });
-			slashCommands.SlashCommandErrored += (_, eventArgs) =>
-			{
-				logger.Error(eventArgs.Exception, "{Username} tried to execute command {CommandName}, but it errored", eventArgs.Context.User.Username, eventArgs.Context.CommandName);
-
-				return Task.CompletedTask;
-			};
-			slashCommands.SlashCommandExecuted += (_, eventArgs) =>
-			{
-				logger.Debug("{Username} executed command {CommandName}", eventArgs.Context.User.Username, eventArgs.Context.CommandName);
-
-				return Task.CompletedTask;
-			};
-
-			// TODO: Register slash commands below
-			// Eg: slashCommands.RegisterCommands<TestSlashCommand>();
-			slashCommands.RegisterCommands<PingCommand>();
-			slashCommands.RegisterCommands<UptimeCommand>();
 		}
 	}
 }

--- a/POI.DiscordDotNet/Commands/Admin/PruneCommand.cs
+++ b/POI.DiscordDotNet/Commands/Admin/PruneCommand.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
-using POI.DiscordDotNet.Commands.Modules;
+using POI.DiscordDotNet.Commands.Modules.ChatCommands;
 
 namespace POI.DiscordDotNet.Commands.Admin
 {

--- a/POI.DiscordDotNet/Commands/BeatSaber/BaseLinkCommand.cs
+++ b/POI.DiscordDotNet/Commands/BeatSaber/BaseLinkCommand.cs
@@ -10,7 +10,7 @@ using DSharpPlus.Interactivity.Extensions;
 using Microsoft.Extensions.Logging;
 using POI.Core.Models.ScoreSaber.Profile;
 using POI.Core.Services;
-using POI.DiscordDotNet.Commands.Modules;
+using POI.DiscordDotNet.Commands.Modules.ChatCommands;
 using POI.DiscordDotNet.Extensions;
 using POI.DiscordDotNet.Services;
 

--- a/POI.DiscordDotNet/Commands/BeatSaber/BaseSongCommand.cs
+++ b/POI.DiscordDotNet/Commands/BeatSaber/BaseSongCommand.cs
@@ -13,7 +13,7 @@ using POI.Core.Models.ScoreSaber.Profile;
 using POI.Core.Models.ScoreSaber.Scores;
 using POI.Core.Models.ScoreSaber.Wrappers;
 using POI.Core.Services;
-using POI.DiscordDotNet.Commands.Modules;
+using POI.DiscordDotNet.Commands.Modules.ChatCommands;
 using POI.DiscordDotNet.Extensions;
 using POI.DiscordDotNet.Models.Database;
 using POI.DiscordDotNet.Services;

--- a/POI.DiscordDotNet/Commands/BeatSaber/CompareCommand.cs
+++ b/POI.DiscordDotNet/Commands/BeatSaber/CompareCommand.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using NodaTime;
 using POI.Core.Services;
-using POI.DiscordDotNet.Commands.Modules;
+using POI.DiscordDotNet.Commands.Modules.ChatCommands;
 using POI.DiscordDotNet.Extensions;
 using POI.DiscordDotNet.Models.Database;
 using POI.DiscordDotNet.Services;

--- a/POI.DiscordDotNet/Commands/Modules/ChatCommands/AdminCommandsModule.cs
+++ b/POI.DiscordDotNet/Commands/Modules/ChatCommands/AdminCommandsModule.cs
@@ -1,6 +1,6 @@
 using DSharpPlus.CommandsNext;
 
-namespace POI.DiscordDotNet.Commands.Modules
+namespace POI.DiscordDotNet.Commands.Modules.ChatCommands
 {
 	public class AdminCommandsModule : BaseCommandModule
 	{

--- a/POI.DiscordDotNet/Commands/Modules/ChatCommands/BeatSaberCommandsModule.cs
+++ b/POI.DiscordDotNet/Commands/Modules/ChatCommands/BeatSaberCommandsModule.cs
@@ -1,6 +1,6 @@
 using DSharpPlus.CommandsNext;
 
-namespace POI.DiscordDotNet.Commands.Modules
+namespace POI.DiscordDotNet.Commands.Modules.ChatCommands
 {
 	public class BeatSaberCommandsModule : BaseCommandModule
 	{

--- a/POI.DiscordDotNet/Commands/Modules/SlashCommands/AdminSlashCommandsModule.cs
+++ b/POI.DiscordDotNet/Commands/Modules/SlashCommands/AdminSlashCommandsModule.cs
@@ -1,0 +1,8 @@
+﻿using DSharpPlus.SlashCommands;
+
+namespace POI.DiscordDotNet.Commands.Modules.SlashCommands
+{
+	public class AdminSlashCommandsModule : ApplicationCommandModule
+	{
+	}
+}

--- a/POI.DiscordDotNet/Commands/Modules/SlashCommands/BeatSaberSlashCommandsModule.cs
+++ b/POI.DiscordDotNet/Commands/Modules/SlashCommands/BeatSaberSlashCommandsModule.cs
@@ -1,0 +1,8 @@
+﻿using DSharpPlus.SlashCommands;
+
+namespace POI.DiscordDotNet.Commands.Modules.SlashCommands
+{
+	public class BeatSaberSlashCommandsModule : ApplicationCommandModule
+	{
+	}
+}

--- a/POI.DiscordDotNet/Commands/Modules/SlashCommands/UtilSlashCommandsModule.cs
+++ b/POI.DiscordDotNet/Commands/Modules/SlashCommands/UtilSlashCommandsModule.cs
@@ -1,0 +1,8 @@
+﻿using DSharpPlus.SlashCommands;
+
+namespace POI.DiscordDotNet.Commands.Modules.SlashCommands
+{
+	public class UtilSlashCommandsModule : ApplicationCommandModule
+	{
+	}
+}

--- a/POI.DiscordDotNet/Commands/Modules/UtilCommandsModule.cs
+++ b/POI.DiscordDotNet/Commands/Modules/UtilCommandsModule.cs
@@ -1,8 +1,0 @@
-using DSharpPlus.CommandsNext;
-
-namespace POI.DiscordDotNet.Commands.Modules
-{
-	public class UtilCommandsModule : BaseCommandModule
-	{
-	}
-}

--- a/POI.DiscordDotNet/Commands/Utils/PingCommand.cs
+++ b/POI.DiscordDotNet/Commands/Utils/PingCommand.cs
@@ -1,21 +1,18 @@
-﻿using System;
-using System.Threading.Tasks;
-using DSharpPlus.CommandsNext;
-using DSharpPlus.CommandsNext.Attributes;
-using POI.DiscordDotNet.Commands.Modules;
+﻿using System.Threading.Tasks;
+using DSharpPlus.SlashCommands;
+using POI.DiscordDotNet.Commands.Modules.SlashCommands;
 
 namespace POI.DiscordDotNet.Commands.Utils
 {
-    public class PingCommand : UtilCommandsModule
-    {
-	    [Command("ping")]
-        public async Task Handle(CommandContext ctx)
-        {
-            await ctx.Channel
-                .SendMessageAsync("POI!\n" +
-                                  $"WS latency: {ctx.Client.Ping} ms\n" +
-                                  $"Message latency: {(DateTimeOffset.Now - ctx.Message.Timestamp):g}")
-                .ConfigureAwait(false);
-        }
-    }
+	public class PingCommand : UtilSlashCommandsModule
+	{
+		[SlashCommand("ping", "Shows how response I am ^^")]
+		public async Task Handle(InteractionContext ctx)
+		{
+			await ctx
+				.CreateResponseAsync("POI!\n" +
+				                     $"WS latency: {ctx.Client.Ping} ms\n")
+				.ConfigureAwait(false);
+		}
+	}
 }

--- a/POI.DiscordDotNet/Commands/Utils/UptimeCommand.cs
+++ b/POI.DiscordDotNet/Commands/Utils/UptimeCommand.cs
@@ -1,14 +1,13 @@
 using System;
 using System.Threading.Tasks;
-using DSharpPlus.CommandsNext;
-using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.SlashCommands;
 using NodaTime.Extensions;
-using POI.DiscordDotNet.Commands.Modules;
+using POI.DiscordDotNet.Commands.Modules.SlashCommands;
 using POI.DiscordDotNet.Services;
 
 namespace POI.DiscordDotNet.Commands.Utils
 {
-    public class UptimeCommand : UtilCommandsModule
+    public class UptimeCommand : UtilSlashCommandsModule
     {
 	    private readonly UptimeManagementService _uptimeManagementService;
 
@@ -17,9 +16,8 @@ namespace POI.DiscordDotNet.Commands.Utils
 	        _uptimeManagementService = uptimeManagementService;
         }
 
-        [Command("uptime")]
-        [Aliases("uppy")]
-        public async Task Handle(CommandContext ctx)
+        [SlashCommand("uppy", "Shows how long I've been online already 😅")]
+        public async Task Handle(InteractionContext ctx)
         {
 	        string message;
             var upSince = _uptimeManagementService.UpSince;
@@ -30,10 +28,10 @@ namespace POI.DiscordDotNet.Commands.Utils
             }
             else
             {
-                message = $"I've been online for... erm... some time I guess Tehe";
+                message = "I've been online for... erm... some time I guess Tehe";
             }
 
-            await ctx.Channel.SendMessageAsync(message).ConfigureAwait(false);
+            await ctx.CreateResponseAsync(message).ConfigureAwait(false);
         }
     }
 }

--- a/POI.DiscordDotNet/Services/SlashCommandsManagementService.cs
+++ b/POI.DiscordDotNet/Services/SlashCommandsManagementService.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Threading.Tasks;
+using DSharpPlus;
+using DSharpPlus.SlashCommands;
+using DSharpPlus.SlashCommands.EventArgs;
+using Microsoft.Extensions.Logging;
+using POI.DiscordDotNet.Commands.Utils;
+
+namespace POI.DiscordDotNet.Services
+{
+	public class SlashCommandsManagementService : IDisposable
+	{
+		private readonly IServiceProvider _serviceProvider;
+		private readonly ILogger<SlashCommandsManagementService> _logger;
+		private readonly DiscordClient _discordClient;
+
+		private SlashCommandsExtension? _slashCommands;
+
+		public SlashCommandsManagementService(IServiceProvider serviceProvider, ILogger<SlashCommandsManagementService> logger, DiscordClient discordClient)
+		{
+			_serviceProvider = serviceProvider;
+			_logger = logger;
+			_discordClient = discordClient;
+		}
+
+		public void Setup()
+		{
+			_slashCommands = _discordClient.UseSlashCommands(new SlashCommandsConfiguration { Services = _serviceProvider });
+			_slashCommands.SlashCommandErrored += OnSlashCommandErrored;
+			_slashCommands.SlashCommandExecuted += OnSlashCommandsExecuted;
+
+			// TODO: Register slash commands below
+			_slashCommands.RegisterCommands<PingCommand>();
+			_slashCommands.RegisterCommands<UptimeCommand>();
+		}
+
+		public void Dispose()
+		{
+			if (_slashCommands == null)
+			{
+				return;
+			}
+
+			_slashCommands.SlashCommandErrored -= OnSlashCommandErrored;
+			_slashCommands.SlashCommandExecuted -= OnSlashCommandsExecuted;
+			_slashCommands = null;
+		}
+
+		private Task OnSlashCommandErrored(SlashCommandsExtension _, SlashCommandErrorEventArgs eventArgs)
+		{
+			_logger.LogError(eventArgs.Exception, "{Username} tried to execute slashcommand /{CommandName}, but it errored", eventArgs.Context.User.Username, eventArgs.Context.CommandName);
+
+			return Task.CompletedTask;
+		}
+
+		private Task OnSlashCommandsExecuted(SlashCommandsExtension _, SlashCommandExecutedEventArgs eventArgs)
+		{
+			_logger.LogDebug("{Username} executed slashcommand /{CommandName}", eventArgs.Context.User.Username, eventArgs.Context.CommandName);
+
+			return Task.CompletedTask;
+		}
+	}
+}


### PR DESCRIPTION
This PR moves the util commands (ping and uptime) to the slashcommand system.
All other commands (eg: score commands and scoresaber account linking) are currently unaffected although some really minor preparation has been done for their migration as well.

This is part of the work for #177.