### PR TITLE
Fix players with rank 0 according to API getting assigned the wrong role

### DIFF
--- a/Src/POI.DiscordDotNet/Jobs/RankUpFeedJob.cs
+++ b/Src/POI.DiscordDotNet/Jobs/RankUpFeedJob.cs
@@ -65,8 +65,8 @@ namespace POI.DiscordDotNet.Jobs
 
 			var roles = OrderTopRoles(guild.Roles.Where(x => x.Value.Name.Contains("(Top ", StringComparison.Ordinal)));
 			var players = playersWrappers
-				.SelectMany(x => x!.Players)
-				.Where(x => x.Pp > 0)
+				.SelectMany(wrapper => wrapper!.Players)
+				.Where(player => player.Pp > 0 && player.Rank > 0)
 				.ToList();
 			foreach (var player in players)
 			{


### PR DESCRIPTION
Probably an incredibly rare edge case, but it happened at least once so better to guard against it in the future.
Anyways, the ScoreSaber API is apparently capable of returning players who have been turned inactive on the normal country leaderboards endpoint. This results in the rankup feed logic granting people the highest possible top role unintentionally.