### PR TITLE
Fix minor issues

### DIFF
--- a/Src/POI.DiscordDotNet/Commands/BeatSaber/ScoreLinkCommand.cs
+++ b/Src/POI.DiscordDotNet/Commands/BeatSaber/ScoreLinkCommand.cs
@@ -62,7 +62,7 @@ namespace POI.DiscordDotNet.Commands.BeatSaber
 		{
 			// Check discordId conflict
 			var userSettings = await GlobalUserSettingsRepository.LookupSettingsByDiscordId(discordId);
-			if (userSettings != null)
+			if (userSettings?.ScoreSaberId != null)
 			{
 				if (userSettings.ScoreSaberId == scoreSaberId)
 				{

--- a/Src/POI.DiscordDotNet/Commands/Utils/UptimeCommand.cs
+++ b/Src/POI.DiscordDotNet/Commands/Utils/UptimeCommand.cs
@@ -2,7 +2,7 @@ using DSharpPlus.SlashCommands;
 using JetBrains.Annotations;
 using NodaTime.Extensions;
 using POI.DiscordDotNet.Commands.Modules.SlashCommands;
-using POI.DiscordDotNet.Services.Implementations;
+using POI.DiscordDotNet.Services;
 
 namespace POI.DiscordDotNet.Commands.Utils
 {

--- a/Src/POI.DiscordDotNet/Services/IUptimeManagementService.cs
+++ b/Src/POI.DiscordDotNet/Services/IUptimeManagementService.cs
@@ -1,6 +1,6 @@
 using NodaTime;
 
-namespace POI.DiscordDotNet.Services.Implementations;
+namespace POI.DiscordDotNet.Services;
 
 public interface IUptimeManagementService
 {


### PR DESCRIPTION
Fixing hopefully the last few issues in the current codebase >.<

- `IUptimeManagementService` was apparently in the wrong namespace
- `ScoreLinkCommand` was wrongfully state that the account of the user is already linked to another `null` account