### PR TITLE
Fix BeatSavior deserialization issue

### DIFF
--- a/Src/POI.ThirdParty.BeatSavior/Helpers/JSON/BeatSaviorSerializerContext.cs
+++ b/Src/POI.ThirdParty.BeatSavior/Helpers/JSON/BeatSaviorSerializerContext.cs
@@ -4,6 +4,7 @@ using POI.ThirdParty.BeatSavior.Models;
 namespace POI.ThirdParty.BeatSavior.Helpers.JSON;
 
 [JsonSerializable(typeof(List<SongDataDto>))]
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
 internal partial class BeatSaviorSerializerContext : JsonSerializerContext
 {
 }

--- a/Src/POI.ThirdParty.BeatSavior/Models/Trackers/AccuracyTrackerDto.cs
+++ b/Src/POI.ThirdParty.BeatSavior/Models/Trackers/AccuracyTrackerDto.cs
@@ -65,6 +65,7 @@ public readonly struct AccuracyTrackerDto
 	public List<double>? AverageCut { get; }
 
 	[JsonPropertyName("gridAcc")]
+	[JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals)]
 	public List<double>? GridAcc { get; }
 
 	[JsonPropertyName("gridCut")]

--- a/Src/POI.ThirdParty.BeatSavior/Services/Implementations/BeatSaviorApiService.cs
+++ b/Src/POI.ThirdParty.BeatSavior/Services/Implementations/BeatSaviorApiService.cs
@@ -29,7 +29,6 @@ internal class BeatSaviorApiService : IBeatSaviorApiService
 	private readonly AsyncRetryPolicy<HttpResponseMessage> _beatSaviorApiRateLimitPolicy;
 	private readonly AsyncRetryPolicy<HttpResponseMessage> _beatSaviorApiInternalServerErrorRetryPolicy;
 
-	private readonly JsonSerializerOptions _jsonSerializerOptions;
 	private readonly BeatSaviorSerializerContext _beatSaviorSerializerContext;
 
 	public BeatSaviorApiService(ILogger<BeatSaviorApiService> logger, IConstants constants)
@@ -43,8 +42,8 @@ internal class BeatSaviorApiService : IBeatSaviorApiService
 			DefaultRequestHeaders = { { "User-Agent", $"{constants.Name}/{constants.Version.ToString(3)}" } }
 		};
 
-		_jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web) { PropertyNameCaseInsensitive = false }.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
-		_beatSaviorSerializerContext = new BeatSaviorSerializerContext(_jsonSerializerOptions);
+		var jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web).ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
+		_beatSaviorSerializerContext = new BeatSaviorSerializerContext(jsonSerializerOptions);
 
 		_beatSaviorApiInternalServerErrorRetryPolicy = Policy
 			.HandleResult<HttpResponseMessage>(resp => resp.StatusCode == HttpStatusCode.InternalServerError)


### PR DESCRIPTION
The GridAcc property on the AccuracyTrackerDto could contain "NaN" string values, resulting in an exception during deserialization.

See https://github.com/dotnet/runtime/issues/79511 for more info