### PR TITLE
Added mod mail slash command to utils module.

### DIFF
--- a/source/POI.DiscordDotNet/Commands/SlashCommands/Modules/UtilSlashCommandsModule.cs
+++ b/source/POI.DiscordDotNet/Commands/SlashCommands/Modules/UtilSlashCommandsModule.cs
@@ -20,5 +20,9 @@ namespace POI.DiscordDotNet.Commands.SlashCommands.Modules
 		[SlashCommand("uppy", "Shows how long I've been online already 😅"), UsedImplicitly]
 		public Task HandleUptimeCommand(InteractionContext ctx)
 			=> ctx.Services.GetRequiredService<UptimeCommand>().Handle(ctx);
+
+		[SlashCommand("modmail", "Send a message to the mods."), UsedImplicitly]
+		public Task HandleSilentMessageCommand(InteractionContext ctx, [Option("Message", "Your message for the moderators.", true)] string message)
+			=> ctx.Services.GetRequiredService<ModMailSlashCommands>().Handle(ctx, message);
 	}
 }

--- a/source/POI.DiscordDotNet/Commands/SlashCommands/Modules/UtilSlashCommandsModule.cs
+++ b/source/POI.DiscordDotNet/Commands/SlashCommands/Modules/UtilSlashCommandsModule.cs
@@ -22,7 +22,7 @@ namespace POI.DiscordDotNet.Commands.SlashCommands.Modules
 			=> ctx.Services.GetRequiredService<UptimeCommand>().Handle(ctx);
 
 		[SlashCommand("modmail", "Send a message to the mods."), UsedImplicitly]
-		public Task HandleSilentMessageCommand(InteractionContext ctx, [Option("Message", "Your message for the moderators.", true)] string message)
-			=> ctx.Services.GetRequiredService<ModMailSlashCommands>().Handle(ctx, message);
+		public Task HandleSilentMessageCommand(InteractionContext ctx, [Option("Message", "Your message for the moderators.", true)] string message, [Option("Anonymously", "Whether you want to remain anonymously.")] bool anonymously = false)
+			=> ctx.Services.GetRequiredService<ModMailSlashCommands>().Handle(ctx, message, anonymously);
 	}
 }

--- a/source/POI.DiscordDotNet/Commands/SlashCommands/Utils/ModMailSlashCommands.cs
+++ b/source/POI.DiscordDotNet/Commands/SlashCommands/Utils/ModMailSlashCommands.cs
@@ -1,0 +1,50 @@
+﻿using DSharpPlus.Entities;
+using DSharpPlus.SlashCommands;
+using Microsoft.Extensions.Logging;
+using POI.DiscordDotNet.Commands.SlashCommands.Modules;
+using POI.Persistence.Repositories;
+
+namespace POI.DiscordDotNet.Commands.SlashCommands.Utils;
+
+public class ModMailSlashCommands : UtilSlashCommandsModule
+{
+	private readonly IServerSettingsRepository _serverSettingsRepository;
+	private readonly ILogger<ModMailSlashCommands> _logger
+		;
+
+	public ModMailSlashCommands(IServerSettingsRepository serverSettingsRepository, ILogger<ModMailSlashCommands> logger)
+	{
+		_serverSettingsRepository = serverSettingsRepository;
+		_logger = logger;
+	}
+
+	public async Task Handle(InteractionContext ctx, string message)
+	{
+		await ctx.CreateResponseAsync("Message has been sent.", true).ConfigureAwait(false);
+		var serverId = ctx.Guild.Id;
+		var serverSettings = await _serverSettingsRepository.FindOneById(serverId);
+		if (serverSettings?.ModMailChannelId == null)
+		{
+			_logger.LogWarning("Server settings or ModMailChannelId for {ServerId} not found", serverId);
+			return;
+		}
+
+		var channelId = serverSettings.ModMailChannelId!.Value;
+		DiscordChannel channel;
+		try{
+			channel = await ctx.Client.GetChannelAsync(channelId);
+		}
+		catch (Exception e)
+		{
+			_logger.LogWarning(e, "Channel {ChannelId} not found for server {ServerId}",channelId, serverId);
+			return;
+		}
+
+		var embed = new DiscordEmbedBuilder()
+			.WithTitle($"New mod mail from {ctx.User.Username}")
+			.WithDescription(message)
+			.WithTimestamp(DateTimeOffset.UtcNow)
+			.Build();
+		await channel.SendMessageAsync(embed).ConfigureAwait(false);
+	}
+}

--- a/source/POI.DiscordDotNet/Commands/SlashCommands/Utils/ModMailSlashCommands.cs
+++ b/source/POI.DiscordDotNet/Commands/SlashCommands/Utils/ModMailSlashCommands.cs
@@ -18,7 +18,7 @@ public class ModMailSlashCommands : UtilSlashCommandsModule
 		_logger = logger;
 	}
 
-	public async Task Handle(InteractionContext ctx, string message)
+	public async Task Handle(InteractionContext ctx, string message, bool anonymously)
 	{
 		await ctx.CreateResponseAsync("Message has been sent.", true).ConfigureAwait(false);
 		var serverId = ctx.Guild.Id;
@@ -39,12 +39,13 @@ public class ModMailSlashCommands : UtilSlashCommandsModule
 			_logger.LogWarning(e, "Channel {ChannelId} not found for server {ServerId}",channelId, serverId);
 			return;
 		}
-
+		var name = anonymously ? "Anonymous" : ctx.User.Username;
 		var embed = new DiscordEmbedBuilder()
-			.WithTitle($"New mod mail from {ctx.User.Username}")
+			.WithTitle($"New mod mail from {name}")
 			.WithDescription(message)
 			.WithTimestamp(DateTimeOffset.UtcNow)
 			.Build();
 		await channel.SendMessageAsync(embed).ConfigureAwait(false);
+		_logger.LogInformation("Mod mail sent from {UserId} to {ChannelId} on {ServerId}", name, channelId, serverId);
 	}
 }

--- a/source/POI.DiscordDotNet/Commands/SlashCommands/Utils/ServiceCollectionExtensions.cs
+++ b/source/POI.DiscordDotNet/Commands/SlashCommands/Utils/ServiceCollectionExtensions.cs
@@ -5,5 +5,5 @@ namespace POI.DiscordDotNet.Commands.SlashCommands.Utils;
 public static class ServiceCollectionExtensions
 {
 	public static IServiceCollection AddUtilitySlashCommands(this IServiceCollection services) => services
-		.AddTransient<UptimeCommand>();
+		.AddTransient<UptimeCommand>().AddTransient<ModMailSlashCommands>();
 }

--- a/source/POI.Persistence.Domain/ServerSettings.cs
+++ b/source/POI.Persistence.Domain/ServerSettings.cs
@@ -14,7 +14,10 @@
 
 		public uint? StarboardEmojiCount { get; set; }
 
-		public ServerSettings(ulong serverId, ulong? rankUpFeedChannelId = null, ulong? birthdayRoleId = null, ulong? starboardChannelId = null, ulong? eventsChannelId = null, uint? starboardEmojiCount = null)
+		public ulong? ModMailChannelId { get; set; }
+
+		public ServerSettings(ulong serverId, ulong? rankUpFeedChannelId = null, ulong? birthdayRoleId = null, ulong? starboardChannelId = null, ulong? eventsChannelId = null,
+			uint? starboardEmojiCount = null, ulong? modMailChannelId = null)
 		{
 			ServerId = serverId;
 			RankUpFeedChannelId = rankUpFeedChannelId;
@@ -22,6 +25,7 @@
 			StarboardChannelId = starboardChannelId;
 			EventsChannelId = eventsChannelId;
 			StarboardEmojiCount = starboardEmojiCount;
+			ModMailChannelId = modMailChannelId;
 		}
 	}
 }

--- a/source/POI.Persistence.EFCore.Npgsql/Migrations/20231023180711_ModMailMigrations.Designer.cs
+++ b/source/POI.Persistence.EFCore.Npgsql/Migrations/20231023180711_ModMailMigrations.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using POI.Persistence.EFCore.Npgsql.Infrastructure;
 namespace POI.Persistence.EFCore.Npgsql.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231023180711_ModMailMigrations")]
+    partial class ModMailMigrations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/source/POI.Persistence.EFCore.Npgsql/Migrations/20231023180711_ModMailMigrations.cs
+++ b/source/POI.Persistence.EFCore.Npgsql/Migrations/20231023180711_ModMailMigrations.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace POI.Persistence.EFCore.Npgsql.Migrations
+{
+    /// <inheritdoc />
+    public partial class ModMailMigrations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "ModMailChannelId",
+                table: "ServerSettings",
+                type: "numeric(20,0)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ModMailChannelId",
+                table: "ServerSettings");
+        }
+    }
+}


### PR DESCRIPTION
This feature has been implemented after a suggestion from Pixelguy in #suggestions.

Usage of the command is **/utils modmail <message> <anonymously?>** where anonymously is an optional  boolean field.
It'll send an embed with the message and sender (or anonymous) to a **configurable channel in de ServerSettings** entity.
Added migration **ModMailMigrations**.
